### PR TITLE
Perf 509

### DIFF
--- a/workflows-scripts/oai-pmh/FullHarvest/oai_pmh_FH.jmx
+++ b/workflows-scripts/oai-pmh/FullHarvest/oai_pmh_FH.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.5">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.0 r1840935">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="oai_pmh_FH" enabled="true">
       <stringProp name="TestPlan.comments"></stringProp>
@@ -54,7 +54,6 @@
       <CookieManager guiclass="CookiePanel" testclass="CookieManager" testname="HTTP Cookie Manager" enabled="true">
         <collectionProp name="CookieManager.cookies"/>
         <boolProp name="CookieManager.clearEachIteration">true</boolProp>
-        <boolProp name="CookieManager.controlledByThreadGroup">false</boolProp>
       </CookieManager>
       <hashTree/>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group" enabled="true">
@@ -79,7 +78,7 @@
             </elementProp>
             <elementProp name="" elementType="Header">
               <stringProp name="Header.name">x-okapi-tenant</stringProp>
-              <stringProp name="Header.value">fs09000000</stringProp>
+              <stringProp name="Header.value">${tenant}</stringProp>
             </elementProp>
             <elementProp name="" elementType="Header">
               <stringProp name="Header.name">content-type</stringProp>
@@ -92,7 +91,7 @@
           <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
-          <stringProp name="HTTPSampler.domain">${HOSTNAME}</stringProp>
+          <stringProp name="HTTPSampler.domain">edge-${HOSTNAME}</stringProp>
           <stringProp name="HTTPSampler.port"></stringProp>
           <stringProp name="HTTPSampler.protocol">https</stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
@@ -171,6 +170,10 @@
             <stringProp name="RegexExtractor.default">null</stringProp>
             <stringProp name="RegexExtractor.match_number"></stringProp>
           </RegexExtractor>
+          <hashTree/>
+          <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Constant Timer" enabled="true">
+            <stringProp name="ConstantTimer.delay">${__Random(400,700)}</stringProp>
+          </ConstantTimer>
           <hashTree/>
         </hashTree>
         <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="/oai/records?verb=ListRecords&amp;apikey=[APIKey]&amp;resumptionToken=[resumptionToken]" enabled="true">
@@ -253,6 +256,10 @@
             <stringProp name="RegexExtractor.match_number"></stringProp>
           </RegexExtractor>
           <hashTree/>
+          <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Constant Timer" enabled="true">
+            <stringProp name="ConstantTimer.delay">${__Random(300,500)}</stringProp>
+          </ConstantTimer>
+          <hashTree/>
         </hashTree>
         <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
           <boolProp name="LoopController.continue_forever">true</boolProp>
@@ -328,6 +335,10 @@
               <stringProp name="RegexExtractor.default"></stringProp>
               <stringProp name="RegexExtractor.match_number"></stringProp>
             </RegexExtractor>
+            <hashTree/>
+            <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Constant Timer" enabled="true">
+              <stringProp name="ConstantTimer.delay">${__Random(200,400)}</stringProp>
+            </ConstantTimer>
             <hashTree/>
           </hashTree>
         </hashTree>

--- a/workflows-scripts/oai-pmh/IncrementalHarvest/README.md
+++ b/workflows-scripts/oai-pmh/IncrementalHarvest/README.md
@@ -6,6 +6,12 @@ Incremental harvesting by dates range
 1. /oai?verb=ListRecords&metadataPrefix=marc21_withholdings&apikey=<apiKey>&from=<start-date>&until=<end-date>
 2. /oai/records?verb=ListRecords&apikey=${APIKey}&resumptionToken=${resumptionToken}
 
+You should use the following Loop count configuration to harvest number of records 
+10k records - Loop count = 98; 
+50k records - Loop count = 499; 
+500K records- Loop count = 5000; 
+1mln records -Loop count = 10000 
+
 
 ##### oai_pmh_IH.jmx Variables
 1. Hostname

--- a/workflows-scripts/oai-pmh/IncrementalHarvest/oai_pmh_IH.jmx
+++ b/workflows-scripts/oai-pmh/IncrementalHarvest/oai_pmh_IH.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.5">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.0 r1840935">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="oai_pmh_IH" enabled="true">
       <stringProp name="TestPlan.comments"></stringProp>
@@ -31,12 +31,17 @@
           </elementProp>
           <elementProp name="untilTime" elementType="Argument">
             <stringProp name="Argument.name">untilTime</stringProp>
-            <stringProp name="Argument.value">${__P(untilTime,2023-01-15)}</stringProp>
+            <stringProp name="Argument.value">${__P(untilTime,2023-10-18)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="metadataPrefix" elementType="Argument">
             <stringProp name="Argument.name">metadataPrefix</stringProp>
             <stringProp name="Argument.value">${__P(metadataPrefix,marc21_withholdings)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="oai_pmh_loops" elementType="Argument">
+            <stringProp name="Argument.name">oai_pmh_loops</stringProp>
+            <stringProp name="Argument.value">${__P(oai_pmh_loops,[oai_pmh_loops])}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
         </collectionProp>
@@ -62,7 +67,6 @@
       <CookieManager guiclass="CookiePanel" testclass="CookieManager" testname="HTTP Cookie Manager" enabled="true">
         <collectionProp name="CookieManager.cookies"/>
         <boolProp name="CookieManager.clearEachIteration">true</boolProp>
-        <boolProp name="CookieManager.controlledByThreadGroup">false</boolProp>
       </CookieManager>
       <hashTree/>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="oai_pmh_IH" enabled="true">
@@ -88,7 +92,7 @@
             </elementProp>
             <elementProp name="" elementType="Header">
               <stringProp name="Header.name">x-okapi-tenant</stringProp>
-              <stringProp name="Header.value">fs09000000</stringProp>
+              <stringProp name="Header.value">${tenant}</stringProp>
             </elementProp>
             <elementProp name="" elementType="Header">
               <stringProp name="Header.name">content-type</stringProp>
@@ -101,7 +105,7 @@
           <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
-          <stringProp name="HTTPSampler.domain">${HOSTNAME}</stringProp>
+          <stringProp name="HTTPSampler.domain">edge-${HOSTNAME}</stringProp>
           <stringProp name="HTTPSampler.port"></stringProp>
           <stringProp name="HTTPSampler.protocol">https</stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
@@ -195,6 +199,10 @@
             <stringProp name="RegexExtractor.match_number"></stringProp>
           </RegexExtractor>
           <hashTree/>
+          <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Constant Timer" enabled="true">
+            <stringProp name="ConstantTimer.delay">${__Random(400,700)}</stringProp>
+          </ConstantTimer>
+          <hashTree/>
         </hashTree>
         <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="/oai/records?verb=ListRecords&amp;apikey=[APIKey]&amp;resumptionToken=[resumptionToken]" enabled="true">
           <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
@@ -276,10 +284,14 @@
             <stringProp name="RegexExtractor.match_number"></stringProp>
           </RegexExtractor>
           <hashTree/>
+          <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Constant Timer" enabled="true">
+            <stringProp name="ConstantTimer.delay">${__Random(300,500)}</stringProp>
+          </ConstantTimer>
+          <hashTree/>
         </hashTree>
         <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
           <boolProp name="LoopController.continue_forever">true</boolProp>
-          <intProp name="LoopController.loops">-1</intProp>
+          <stringProp name="LoopController.loops">${oai_pmh_loops}</stringProp>
         </LoopController>
         <hashTree>
           <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="/oai/records?verb=ListRecords&amp;apikey=[APIKey]&amp;resumptionToken=[resumptionToken]" enabled="true">
@@ -351,6 +363,10 @@
               <stringProp name="RegexExtractor.default"></stringProp>
               <stringProp name="RegexExtractor.match_number"></stringProp>
             </RegexExtractor>
+            <hashTree/>
+            <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Constant Timer" enabled="true">
+              <stringProp name="ConstantTimer.delay">${__Random(200,400)}</stringProp>
+            </ConstantTimer>
             <hashTree/>
           </hashTree>
         </hashTree>

--- a/workflows-scripts/oai-pmh/IncrementalHarvest/oai_pmh_IH.jmx
+++ b/workflows-scripts/oai-pmh/IncrementalHarvest/oai_pmh_IH.jmx
@@ -43,6 +43,7 @@
             <stringProp name="Argument.name">oai_pmh_loops</stringProp>
             <stringProp name="Argument.value">${__P(oai_pmh_loops,[oai_pmh_loops])}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
+            <stringProp name="Argument.desc">10k - 98; 50k-499; 500K-5000; 1mln-10000 </stringProp>
           </elementProp>
         </collectionProp>
       </Arguments>


### PR DESCRIPTION
According to "[OAI-PMH] JMeter Script updates" ticket to make the JMeter script work more closely with the harvester, was added
1) To the first  request /oai/records?verb=ListRecords&metadataPrefix=marc21_withholdings&apikey=[APIKey], a timer was added which waits from 400 to 700 ms

2) To the second request /oai/records?verb=ListRecords&apikey=[APIKey]&resumptionToken=[resumptionToken] A timer was added which waits from 300 to 500 ms
3) And a timer was added to the previous request, which is in a loop, which waits from 200 to 400 ms. 
