### PR TITLE
PERF-1163: aws.sdk 1.12.788 fixing 70 jackson security vulnerabilities

### DIFF
--- a/common/ECSResourcesCheck/pom.xml
+++ b/common/ECSResourcesCheck/pom.xml
@@ -62,6 +62,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <aws.sdk>1.11.214</aws.sdk>
+        <aws.sdk>1.12.788</aws.sdk>
     </properties>
 </project>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/PERF-1163

Upgrade om.amazonaws:aws-java-sdk from 1.11.214 to 1.12.788.

This indirectly upgrades the transitive jackson dependencies:

* jackson-databind from 2.6.7.1 to 2.17.2
* jackson-annotations from 2.6.0 to 2.17.2
* jackson-core from 2.6.7 to 2.17.2
* jackson-dataformat-cbor from 2.6.7 to 2.17.2

The jackson upgrades fix these vulnerabilities:

* https://security.snyk.io/package/maven/com.fasterxml.jackson.core%3Ajackson-core/2.6.7 (5 vulns)
* https://security.snyk.io/package/maven/com.fasterxml.jackson.core%3Ajackson-databind/2.6.7.1 (64 vulns)
* https://security.snyk.io/package/maven/com.fasterxml.jackson.dataformat%3Ajackson-dataformat-cbor/2.6.0 (1 vuln)